### PR TITLE
uppercase for server option

### DIFF
--- a/bin/metrics-jenkins-jqs.rb
+++ b/bin/metrics-jenkins-jqs.rb
@@ -48,7 +48,7 @@ class JenkinsJQSMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   option :server,
          description: 'Jenkins Host',
-         short: '-s SERVER',
+         short: '-S SERVER',
          long: '--server SERVER',
          default: 'localhost'
 

--- a/bin/metrics-jenkins.rb
+++ b/bin/metrics-jenkins.rb
@@ -48,7 +48,7 @@ class JenkinsMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   option :server,
          description: 'Jenkins Host',
-         short: '-s SERVER',
+         short: '-S SERVER',
          long: '--server SERVER',
          default: 'localhost'
 


### PR DESCRIPTION
Both server and scheme have the same short option name. I've just uppercase the server option.
