### PR TITLE
Secure Jenkins communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [0.0.6] - 2015-12-08
 ### Added
 - Enhanced error messages in particular when the check configuration is wrong 
+- Update dependent jenkins-api version to 1.4.2
+- Changed check-jenkins-job-status.rb and check-jenkins-build-time.rb to use server_url to allow
+  passing credentials
 
 ## [0.0.5] - 2015-08-24
 ### Added

--- a/bin/check-jenkins-build-time.rb
+++ b/bin/check-jenkins-build-time.rb
@@ -84,7 +84,7 @@ class JenkinsBuildTime < Sensu::Plugin::Check::CLI
   private
 
   def jenkins
-    @jenkins ||= JenkinsApi::Client.new(server_ip: config[:url], log_level: 3)
+    @jenkins ||= JenkinsApi::Client.new(server_url: config[:url], log_level: 3)
   end
 
   def last_successful_build_number(job_name)

--- a/bin/check-jenkins-job-status.rb
+++ b/bin/check-jenkins-job-status.rb
@@ -66,7 +66,7 @@ class JenkinsJobChecker < Sensu::Plugin::Check::CLI
 
   def jenkins_api_client
     @jenkins_api_client ||= JenkinsApi::Client.new(
-      server_ip: config[:server_api_url],
+      server_url: config[:server_api_url],
       log_level: config[:client_log_level].to_i
     )
   end

--- a/sensu-plugins-jenkins.gemspec
+++ b/sensu-plugins-jenkins.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'sensu-plugin',        '1.2.0'
   s.add_runtime_dependency 'rest-client',         '1.8.0'
-  s.add_runtime_dependency 'jenkins_api_client',  '1.3.0'
+  s.add_runtime_dependency 'jenkins_api_client',  '1.4.2'
   s.add_runtime_dependency 'chronic_duration',    '0.10.6'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
- Updated jenkins-api version to 1.4.2
- Changed jenkins-build-time and jenkins-job-status checks to use server_url to allow
  passing of user credentials and port to the jenkins-api (e.g
  ./check-jenkins-build-time.rb -u http://USER:PASSWORD@127.0.0.1:8080 -j JENKINS_JOB)
- Verified all checks work the latest api version as well (will post details later)
- Updated CHANGELOG
