### PR TITLE
If a job build is in progress, get the status of the last build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- If a job is in progress, use the result of the last completed build instead
 
 ## [0.1.0] - 2015-12-14
 ### Added

--- a/bin/check-jenkins-job-status.rb
+++ b/bin/check-jenkins-job-status.rb
@@ -84,7 +84,14 @@ class JenkinsJobChecker < Sensu::Plugin::Check::CLI
   end
 
   def job_status(job_name)
-    jenkins_api_client.job.get_current_build_status(job_name)
+    status = jenkins_api_client.job.get_current_build_status(job_name)
+    # If the job is currently running, get the status of the last build instead
+    if status == 'running'
+      last_build = jenkins_api_client.job.get_current_build_number(job_name) - 1
+      build = jenkins_api_client.job.get_build_details(job_name, last_build)
+      status = build['result'].downcase
+    end
+    status
   rescue
     critical "Error looking up Jenkins job: #{job_name}"
   end


### PR DESCRIPTION
This avoids a situation where a job fails, generates a problem
event and then suddenly recovers when the job goes in progress
without having really had a success result.

Closes: #12
