### PR TITLE
Add configuration option for timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Changed
-- additional information given on errors in check-jenkins-health.rb
+- Additional information given on errors in check-jenkins-health.rb
+- Add configuration option for timeout in check-jenkins-health.rb
 
 ## [1.1.0] - 2016-10-06
 ### Added


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No.
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

Adds a configuration option for the request timeout with a default of 5
seconds.
#### Known Compatablity Issues

None. Change is backwards compatible.
