### PR TITLE
Fix testurl

### DIFF
--- a/bin/check-jenkins.rb
+++ b/bin/check-jenkins.rb
@@ -60,7 +60,8 @@ class JenkinsMetricsPingPongChecker < Sensu::Plugin::Check::CLI
 
   def run
     https ||= config[:https] ? 'https' : 'http'
-    r = RestClient::Resource.new("#{https}://#{config[:server]}:#{config[:port]}#{config[:uri]}", timeout: 5).get
+    testurl = "#{https}://#{config[:server]}:#{config[:port]}#{config[:uri]}"
+    r = RestClient::Resource.new(testurl, timeout: 5).get
     if r.code == 200 && r.body.include?('pong')
       ok 'Jenkins Service is up'
     else


### PR DESCRIPTION
The 'testurl' parameter used in the rescue block is not set, generating an error when it occurs.