### PR TITLE
Unstable as warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Additional parameter -w to report unstable jobs as a Sensu warning
 
 ## [1.2.0] - 2016-11-11
 ### Added

--- a/bin/check-jenkins-job-status.rb
+++ b/bin/check-jenkins-job-status.rb
@@ -77,7 +77,7 @@ class JenkinsJobChecker < Sensu::Plugin::Check::CLI
   def run
     if failed_jobs.any?
       critical "Jobs reporting failure: #{failed_job_names}, jobs reported as unstable: #{unstable_job_names}"
-    elsif unstable_jobs.any? and config[:include_warnings]
+    elsif unstable_jobs.any? && config[:include_warnings]
       warning "Jobs reported as unstable: #{unstable_job_names}"
     else
       ok 'All queried jobs report success'
@@ -95,14 +95,15 @@ class JenkinsJobChecker < Sensu::Plugin::Check::CLI
   end
 
   def jobs_statuses
-    @job_listing ||= if config[:job_list] =~ /\^/
-      jenkins_api_client.job.list(config[:job_list]).reduce({}) do |listing, job_name| # rubocop:disable Style/EachWithObject
-        listing[job_name] = job_status(job_name)
-        listing
+    @job_listing ||=
+      if config[:job_list] =~ /\^/
+        jenkins_api_client.job.list(config[:job_list]).reduce({}) do |listing, job_name| # rubocop:disable Style/EachWithObject
+          listing[job_name] = job_status(job_name)
+          listing
+        end
+      else
+        { config[:job_list] => job_status(config[:job_list]) }
       end
-    else
-      { config[:job_list] => job_status(config[:job_list]) }
-    end
   end
 
   def job_status(job_name)


### PR DESCRIPTION
This adds an additional parameter `-w` which causes unstable jobs to be logged as a warning. Right now, only failed jobs are logged. Logging only failed jobs remains the default behaviour to preserve compatibility with existing setups.

## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

not applicable

#### Purpose

please see above

#### Known Compatablity Issues

none

