### PR TITLE
Fix check-jenkins-health crash on 500 status response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ### Fixed
 - check-jenkins-health.rb: added various rescues to prevent from bricking (@mdzidic) (@majormoses)
 
+### Added
+- check-jenkins-health.rb: added `--versbose` option to allow user to control the output returned when you have an error (@majormoses)
+
 ## [1.6.0] - 2018-02-21
 ### Added
 - check-jenkins.rb: Add --insecure parameter to allow self signed ssl certs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines](https://g
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- check-jenkins-health.rb: added various rescues to prevent from bricking (@mdzidic) (@majormoses)
+
 ## [1.6.0] - 2018-02-21
 ### Added
 - check-jenkins.rb: Add --insecure parameter to allow self signed ssl certs


### PR DESCRIPTION
Added fix to not raise exceptions but return the response.

Error log:

> Check failed to run: 500 Internal Server Error, ["/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/rest-client-2.0.0/lib/restclient/abstract_response.rb:223:in `exception_with_response'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/rest-client-2.0.0/lib/restclient/abstract_response.rb:103:in `return!'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/rest-client-2.0.0/lib/restclient/request.rb:860:in `process_result'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/rest-client-2.0.0/lib/restclient/request.rb:776:in `block in transmit'", "/opt/sensu/embedded/lib/ruby/2.3.0/net/http.rb:853:in `start'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/rest-client-2.0.0/lib/restclient/request.rb:766:in `transmit'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/rest-client-2.0.0/lib/restclient/request.rb:215:in `execute'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/rest-client-2.0.0/lib/restclient/request.rb:52:in `execute'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/rest-client-2.0.0/lib/restclient/resource.rb:51:in `get'", "/etc/sensu/plugins/check-jenkins-health.rb:73:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.4.4/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]

## Pull Request Checklist

**Is this in reference to an existing issue?**
#10

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

#### Known Compatibility Issues

