### PR TITLE
Add timeout parameter and report request duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ## [Unreleased]
 ### Added
 - Add Ruby 2.4.1 testing
+- metrics-jenkins.rb: Add --timeout parameter + report of the request duration
 
 ### Fixed
 - lock dependency on `rb-readline` to remove deprecation warnings about fixnum (@majormoses)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ### Fixed
 - lock dependency on `rb-readline` to remove deprecation warnings about fixnum (@majormoses)
+- metrics-jenkins.rb: timeout not timing out properly
 
 ### Changed
 - update changelog format location (@majormoses)

--- a/bin/metrics-jenkins.rb
+++ b/bin/metrics-jenkins.rb
@@ -110,9 +110,11 @@ class JenkinsMetrics < Sensu::Plugin::Metric::CLI::Graphite
       end
       ok
     rescue Errno::ECONNREFUSED
-      critical 'Jenkins is not responding'
+      STDERR.write "Jenkins is not responding\n"
+      critical
     rescue RestClient::RequestTimeout
-      critical 'Jenkins Connection timed out'
+      STDERR.write "Jenkins Connection timed out\n"
+      critical
     ensure
       report_request_duration
     end

--- a/bin/metrics-jenkins.rb
+++ b/bin/metrics-jenkins.rb
@@ -71,10 +71,33 @@ class JenkinsMetrics < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Enabling https connections',
          default: false
 
+  option :timeout,
+         short: '-t SECONDS',
+         long: '--timeout SECONDS',
+         description: 'Timeout for REST request',
+         proc: proc(&:to_i),
+         default: 10
+
+  option :report_request_duration,
+         long: '--[no-]report-request-duration',
+         boolean: true,
+         description: 'Report the duration of the REST request',
+         default: true
+
+  def report_request_duration
+    return unless config[:report_request_duration]
+    @stop ||= DateTime.now
+    ms = ((@stop - @start) * 1000 * 24 * 60 * 60).to_i
+    output("#{config[:scheme]}.request.duration", ms)
+  end
+
   def run
+    @start = DateTime.now
+    @stop = nil
     begin
       https ||= config[:https] ? 'https' : 'http'
-      r = RestClient::Resource.new("#{https}://#{config[:server]}:#{config[:port]}#{config[:uri]}", timeout: 5).get
+      r = RestClient::Resource.new("#{https}://#{config[:server]}:#{config[:port]}#{config[:uri]}", timeout: config[:timeout]).get
+      @stop = DateTime.now
       all_metrics = JSON.parse(r)
       metric_groups = all_metrics.keys - SKIP_ROOT_KEYS
       metric_groups.each do |metric_groups_key|
@@ -90,6 +113,8 @@ class JenkinsMetrics < Sensu::Plugin::Metric::CLI::Graphite
       critical 'Jenkins is not responding'
     rescue RestClient::RequestTimeout
       critical 'Jenkins Connection timed out'
+    ensure
+      report_request_duration
     end
     ok
   end

--- a/sensu-plugins-jenkins.gemspec
+++ b/sensu-plugins-jenkins.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsJenkins::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin',        '~> 1.2'
-  s.add_runtime_dependency 'rest-client',         '1.8.0'
+  s.add_runtime_dependency 'rest-client',         '2.0.2'
   s.add_runtime_dependency 'jenkins_api_client',  '1.4.2'
   s.add_runtime_dependency 'chronic_duration',    '0.10.6'
   s.add_runtime_dependency 'rb-readline',         ['>= 0.5.5', '<= 1.0']


### PR DESCRIPTION
Jenkins stopped responding to metrics while being functional for
about 1 hour one night.
It was busy at that time so I wonder if by extending the request timeout
it would have been able to get some data, and if so I want to be
able to monitor the request duration to see what it looks like.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
