### PR TITLE
When a health check fails a status code of 500 is returned.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines](https://g
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- check-jenkins-health.rb: added various rescues to prevent from bricking (@mdzidic) (@majormoses) (@yuri-zubov)
 ## [1.6.0] - 2018-02-21
 ### Added
 - check-jenkins.rb: Add --insecure parameter to allow self signed ssl certs


### PR DESCRIPTION
Parse health check JSON response in error case

When a health check fails a status code of 500 is returned. To get a
meaningful error message, the JSON response needs to be parsed also for
status code 500.

```bash
curl -sn http://172.16.0.4:8080/metrics/$APIKEY/healthcheck | jq .
{
 "disk-space": {
   "healthy": true
 },
 "mesos": {
   "healthy": true
 },
 "plugins": {
   "healthy": false,
   "message": "There are 13 failed plugins: workflow-durable-task-step; docker-workflow; pipeline-model-definition; blueocean-pipeline-api-impl; blueocean-events; blueocean-bitbucket-pipeline; blueocean-git-pipeline; pyenv-pipeline; workflow-aggregator; blueocean-github-pipeline; blueocean-pipeline-editor; blueocean; ws-cleanup"
 },
 "temporary-space": {
   "healthy": true
 },
 "thread-deadlock": {
   "healthy": true
 }
}
```

before the fix
plugin return 
```bash
bin/check-jenkins-health.rb -t 15 -u /metrics/Dg9rH4iCIjTEBQwWDeYfPstOw9xfX4UBg1ykJucszPFv-GDX9DWUv3JasMtFlgmr/healthcheck
Check failed to run: 500 Internal Server Error, [\"/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-2.0.2/lib/restclient/abstract_response.rb:223:in `exception_with_response'\", \"/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-2.0.2/lib/restclient/abstract_response.rb:103:in `return!'\", \"/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-2.0.2/lib/restclient/request.rb:809:in `process_result'\", \"/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-2.0.2/lib/restclient/request.rb:725:in `block in transmit'\", \"/opt/sensu/embedded/lib/ruby/2.4.0/net/http.rb:877:in `start'\", \"/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-2.0.2/lib/restclient/request.rb:715:in `transmit'\", \"/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-2.0.2/lib/restclient/request.rb:145:in `execute'\", \"/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-2.0.2/lib/restclient/request.rb:52:in `execute'\", \"/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rest-client-2.0.2/lib/restclient/resource.rb:51:in `get'\", \"/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-jenkins-1.4.0/bin/check-jenkins-health.rb:73:in `run'\", \"/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugin-1.4.5/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'\"]
```

after the fix
plugin return
```bash
bin/check-jenkins-health.rb -t 15 -u /metrics/Dg9rH4iCIjTEBQwWDeYfPstOw9xfX4UBg1ykJucszPFv-GDX9DWUv3JasMtFlgmr/healthcheck
JenkinsMetricsHealthChecker CRITICAL: Jenkins health check 'disk-space' reported unhealthy state. Message: Only 0.549 Gb free on (master)
```

