### PR TITLE
Provide mode to check build durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines](https://g
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- check-jenkins-build-time.rb: add `--check-build-duration` mode to check duration (@CoRfr)
 
 ## [1.6.2] - 2018-03-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 - check-jenkins-build-time.rb: add `--check-build-duration` mode to check duration (@CoRfr)
+- check-jenkins.rb: add `--timeout` option to specify timeout instead of the hardcoded 5s (@CoRfr)
 
 ## [1.6.2] - 2018-03-01
 ### Fixed

--- a/bin/check-jenkins.rb
+++ b/bin/check-jenkins.rb
@@ -65,16 +65,23 @@ class JenkinsMetricsPingPongChecker < Sensu::Plugin::Check::CLI
          description: 'Perform "insecure" SSL connections and transfers.',
          default: false
 
+  option :timeout,
+         short: '-t SECONDS',
+         long: '--timeout SECONDS',
+         description: 'Timeout for REST request',
+         proc: proc(&:to_i),
+         default: 5
+
   def run
     https ||= config[:https] ? 'https' : 'http'
     testurl = "#{https}://#{config[:server]}:#{config[:port]}#{config[:uri]}"
 
     r = if config[:https] && config[:insecure]
-          RestClient::Resource.new(testurl, timeout: 5, verify_ssl: false).get
+          RestClient::Resource.new(testurl, timeout: config[:timeout], verify_ssl: false).get
         elsif config[:https]
-          RestClient::Resource.new(testurl, timeout: 5, verify_ssl: true).get
+          RestClient::Resource.new(testurl, timeout: config[:timeout], verify_ssl: true).get
         else
-          RestClient::Resource.new(testurl, timeout: 5).get
+          RestClient::Resource.new(testurl, timeout: config[:timeout]).get
         end
 
     if r.code == 200 && r.body.include?('pong')


### PR DESCRIPTION
This adds a mode so that check-jenkins-build-time can check the build
duration instead of when a build last occured.

The goal is to monitor the performance of some jobs.

Signed-off-by: Bertrand Roussel <broussel@sierrawireless.com>

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
