### PR TITLE
Fix issue when multiple builds are currently running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines](https://g
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- check-jenkins-job-status.rb: fix issue when multiple builds are currently running (@CoRfr)
 
 ## [1.7.0] - 2018-05-14
 ### Added

--- a/bin/check-jenkins-job-status.rb
+++ b/bin/check-jenkins-job-status.rb
@@ -110,9 +110,10 @@ class JenkinsJobChecker < Sensu::Plugin::Check::CLI
     status = jenkins_api_client.job.get_current_build_status(job_name)
     # If the job is currently running, get the status of the last build instead
     if status == 'running'
-      last_build = jenkins_api_client.job.get_current_build_number(job_name) - 1
-      build = jenkins_api_client.job.get_build_details(job_name, last_build)
-      status = build['result'].downcase
+      build = jenkins_api_client.job.get_build_details(job_name, 'lastCompletedBuild')
+      if build && build['result']
+        status = build['result'].downcase
+      end
     end
     status
   rescue


### PR DESCRIPTION
When checking the status of a build, and it is in a 'running' state,
it would check the previous build.
However there is not guarantee that this build is not running as well,
which results in a build['result'] that is nil, and an exception.

This uses the 'lastCompletedBuild' alias to get the last completed
build, since we are sure that this one is not running.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
