### PR TITLE
Update to latest sensu-plugins version (2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines](https://g
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Changes
+- bumped dependency of `sensu-plugin` to `>= 2.5 && < 3.0` you can read about it [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07)
 
 ## [1.7.1] - 2018-06-10
 ### Fixed

--- a/bin/check-jenkins-health.rb
+++ b/bin/check-jenkins-health.rb
@@ -111,7 +111,7 @@ class JenkinsMetricsHealthChecker < Sensu::Plugin::Check::CLI
     # if you have a 500 it will only reach here if you are not specifying `--verbose`
     # as it will be caught by the rescue above
     if [200, 500].include?(r.code)
-      healthchecks = JSON.parse(r)
+      healthchecks = ::JSON.parse(r)
       healthchecks.each do |healthcheck, healthcheck_hash_value|
         if healthcheck_hash_value['healthy'] != true
           critical "Jenkins health check '#{healthcheck}' reported unhealthy state. Message: #{healthcheck_hash_value['message']}"

--- a/bin/metrics-jenkins-jqs.rb
+++ b/bin/metrics-jenkins-jqs.rb
@@ -75,7 +75,7 @@ class JenkinsJQSMetrics < Sensu::Plugin::Metric::CLI::Graphite
     begin
       https ||= config[:https] ? 'https' : 'http'
       r = RestClient::Resource.new("#{https}://#{config[:server]}:#{config[:port]}#{config[:uri]}", timeout: 5).get
-      all_metrics = JSON.parse(r)
+      all_metrics = ::JSON.parse(r)
       metric_groups = all_metrics.keys - SKIP_ROOT_KEYS
       metric_groups.each do |metric_groups_key|
         all_metrics[metric_groups_key].each do |metric_key, metric_value|

--- a/bin/metrics-jenkins.rb
+++ b/bin/metrics-jenkins.rb
@@ -114,7 +114,7 @@ class JenkinsMetrics < Sensu::Plugin::Metric::CLI::Graphite
           end
 
       @stop = DateTime.now
-      all_metrics = JSON.parse(r)
+      all_metrics = ::JSON.parse(r)
       metric_groups = all_metrics.keys - SKIP_ROOT_KEYS
       metric_groups.each do |metric_groups_key|
         all_metrics[metric_groups_key].each do |metric_key, metric_value|

--- a/sensu-plugins-jenkins.gemspec
+++ b/sensu-plugins-jenkins.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsJenkins::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin',        '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin',        '~> 2.5'
   s.add_runtime_dependency 'rest-client',         '2.0.2'
   s.add_runtime_dependency 'jenkins_api_client',  '1.4.2'
   s.add_runtime_dependency 'chronic_duration',    '0.10.6'


### PR DESCRIPTION
Some other plugins are starting to use newer versions of sensu-plugin,
which is resulting in the following error because this plugin also
ends up using 2.5:

Check failed to run: undefined method `parse' for
Sensu::Plugin::Metric::CLI::JSON:Class,
["/usr/local/bundle/bin/metrics-jenkins.rb:117:in `run'",
"/usr/local/bundle/gems/sensu-plugin-2.5.0/lib/sensu-plugin/cli.rb:57:in
`block in <class:CLI>'"]

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
